### PR TITLE
fix: Use `VITE_SERVER_URL` instead of `VITE_PROD_SERVER_URL` for the …

### DIFF
--- a/src/libs/store/kribiStore/baseApi.ts
+++ b/src/libs/store/kribiStore/baseApi.ts
@@ -1,6 +1,6 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
-const SERVER_PROD_NAME = import.meta.env.VITE_PROD_SERVER_URL
+const SERVER_PROD_NAME = import.meta.env.VITE_SERVER_URL
 
 export const baseApi = createApi({
   reducerPath: "api",


### PR DESCRIPTION
…base API server name.